### PR TITLE
add option 'update'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,19 @@ jobs:
       with:
         msystem: ${{ matrix.task }}
     - run: msys2do ./test.sh
+
+  update:
+    strategy:
+      matrix:
+        task: [ MSYS, MINGW64, MINGW32 ]
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: install deps
+      run: npm ci
+    - name: run action
+      uses: ./
+      with:
+        update: True
+        msystem: ${{ matrix.task }}
+    - run: msys2do ./test.sh

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The latest tarball available at [repo.msys2.org/distrib/x86_64](http://repo.msys
   - run: msys2do uname -a
 ```
 
+### Options
+
+#### msystem
+
 By default, `MSYSTEM` is set to `MINGW64`. However, an optional parameter named `msystem` is supported, which expects `MSYS`, `MINGW64` or `MING32`. For example:
 
 ```yaml
@@ -30,4 +34,14 @@ Furthermore, the environment variable can be overriden. This is useful when mult
   - run: |
       set MSYSTEM=MINGW64
       msys2do <command to test the package>
+```
+
+#### update
+
+By default, the installation is not updated; hence package versions are those of the installation tarball. By setting option `update` to `true`, the action will execute `pacman -Syu --no-confirm`:
+
+```yaml
+  - uses: numworks/setup-msys2@v1
+    with:
+      update: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Variant of the environment to set by default: MSYS, MINGW32 or MINGW64'
     required: false
     default: 'MINGW64'
+  update:
+    description: 'Update MSYS2 installation through pacman'
+    required: false
+    default: false
 runs:
   using: 'node12'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -45,7 +45,11 @@ async function run() {
 
     core.startGroup('Starting MSYS2 for the first time...');
       // For some reason, `msys2do` does not work
-      await exec.exec(`"${cmd}"`, ['uname', '-a']);
+      await exec.exec(`"${cmd}"`, (core.getInput('update') == 'true') ?
+        ['pacman', '-Syu', '--noconfirm']
+        :
+        ['uname', '-a']
+      );
     core.endGroup();
   }
   catch (error) {


### PR DESCRIPTION
Currently, `uname -a` is executed by default after extracting MSYS2. The purpose of executing it is to initialize the environment, so it is not delayed until the user calls the first command.

This PR adds option/parameter `update`, which will replace `uname -a` with `pacman -Syu --noconfirm`. On the one hand, this makes the initialization call actually useful, instead of being "dummy". On the other hand, updating the environment allows to use packages which were published after the tarball was released/cached.

Corresponding tests are added to the GHA worklow, and the README is updated.