### PR TITLE
Add option 'path-type'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
         msystem: ${{ matrix.task }}
     - run: msys2do ./test.sh ${{ matrix.task }}
 
-  path_env:
+  MSYS2_PATH_TYPE:
     runs-on: windows-latest
     steps:
       - uses: actions/setup-go@v1
@@ -113,3 +113,14 @@ jobs:
       - run: msys2do go env
         env:
           MSYS2_PATH_TYPE: inherit
+
+  path-type:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/setup-go@v1
+      - uses: actions/checkout@v1
+      - run: yarn
+      - uses: ./
+        with:
+          path-type: inherit
+      - run: msys2do go env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,3 +102,14 @@ jobs:
         update: True
         msystem: ${{ matrix.task }}
     - run: msys2do ./test.sh ${{ matrix.task }}
+
+  path_env:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/setup-go@v1
+      - uses: actions/checkout@v1
+      - run: yarn
+      - uses: ./
+      - run: msys2do go env
+        env:
+          MSYS2_PATH_TYPE: inherit

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ Furthermore, the environment variable can be overriden. This is useful when mult
       msys2do <command to test the package>
 ```
 
+#### path-type
+
+By default, `MSYS2_PATH_TYPE` is set to `strict` by `msys2do`. It is possible to override it either using an option or setting the environment variable explicitly:
+
+```yaml
+  - uses: numworks/setup-msys2@v1
+    with:
+      path-type: inherit
+  - run: msys2do <command>
+```
+
+```yaml
+  - uses: numworks/setup-msys2@v1
+  - run: msys2do <command>
+    env:
+      MSYS2_PATH_TYPE: inherit
+```
+
 #### update
 
 By default, the installation is not updated; hence package versions are those of the installation tarball. By setting option `update` to `true`, the action will execute `pacman -Syu --no-confirm`:

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Variant of the environment to set by default: MSYS, MINGW32 or MINGW64'
     required: false
     default: 'MINGW64'
+  path-type:
+    description: 'Default value for MSYS2_PATH_TYPE environment variable: strict, inherit or minimal'
+    required: false
+    default: 'strict'
   update:
     description: 'Update MSYS2 installation through pacman'
     required: false

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ async function run() {
     let cmd = path.join(dest, 'msys2do.cmd');
     fs.writeFileSync(cmd, [
       'setlocal',
-      'set MSYS2_PATH_TYPE=strict',
+      'IF NOT DEFINED MSYS2_PATH_TYPE set MSYS2_PATH_TYPE=strict',
       `%~dp0\\msys64\\usr\\bin\\bash.exe -ilc "cd $OLDPWD && %*"`
     ].join('\r\n'));
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ async function run() {
     let cmd = path.join(dest, 'msys2do.cmd');
     fs.writeFileSync(cmd, [
       'setlocal',
-      'IF NOT DEFINED MSYS2_PATH_TYPE set MSYS2_PATH_TYPE=strict',
+      'IF NOT DEFINED MSYS2_PATH_TYPE set MSYS2_PATH_TYPE=' + core.getInput('path-type'),
       `%~dp0\\msys64\\usr\\bin\\bash.exe -ilc "cd $OLDPWD && %*"`
     ].join('\r\n'));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.1.3.tgz",
-      "integrity": "sha512-2BIib53Jh4Cfm+1XNuZYYGTeRo8yiWEAUMoliMh1qQGMaqTF4VUlhhcsBylTu4qWmUx45DrY0y0XskimAHSqhw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-ZKdyhlSlyz38S6YFfPnyNgCDZuAF2T0Qv5eHflNWytPS8Qjvz39bZFMry9Bb/dpSnqWcNeav5yM2CTYpJeY+Dw=="
     },
     "@actions/exec": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/numworks/setup-msys2",
   "dependencies": {
-    "@actions/core": "^1.1.3",
+    "@actions/core": "^1.2.0",
     "@actions/exec": "^1.0.1",
     "@actions/tool-cache": "1.1.2"
   }

--- a/test.sh
+++ b/test.sh
@@ -1,10 +1,25 @@
 #!/usr/bin/env sh
 
-uname -a
+ANSI_RED="\033[31m"
+ANSI_CYAN="\033[36;1m"
+ANSI_NOCOLOR="\033[0m"
 
-env | grep MSYS
+run_cmd() {
+  printf "${ANSI_CYAN}"
+  echo "$@"
+  printf "${ANSI_NOCOLOR}"
+  "$@"
+}
+
+run_cmd uname -a
+
+env | run_cmd grep MSYSTEM
+
+if [ "x$MSYSTEM" != "xMSYS" ]; then
+  env | run_cmd grep MINGW
+fi
 
 if [ "x$MSYSTEM" != "x$1" ]; then
-  echo "Error MSYSTEM: '$MSYSTEM' != '$1'"
+  printf "${ANSI_RED}Error MSYSTEM: '$MSYSTEM' != '$1'${ANSI_NOCOLOR}\n"
   exit 1
 fi


### PR DESCRIPTION
Fix #13

In this PR, two procedures to override the default value of `MSYS2_PATH_TYPE` are provided. On the one hand, if users set the environment variable, it is not overwritten. On the other hand, option `pathType` can be used to set the default. Supported values are `strict`, `inherit`, or any other (`minimal`).

Two tests are added to the workflow, one for each procedure.

BTW, `@actions/core` is updated.