### PR TITLE
add cron schedule to workflow 'test'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: 'action'
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 3,6'
 jobs:
   set:
     runs-on: windows-latest


### PR DESCRIPTION
Branch `master` was last tested more than a month ago. In this period, the environment might have changed. This PR schedules workflow 'test' to be executed twice a weeek, apart from push and pull requests.