### PR TITLE
fix workflow 'test'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,15 @@ jobs:
     - name: test MSYS
       run: |
         set MSYSTEM=MSYS
-        msys2do ./test.sh
+        msys2do ./test.sh MSYS
     - name: test MINGW64
       run: |
         set MSYSTEM=MINGW64
-        msys2do ./test.sh
+        msys2do ./test.sh MINGW64
     - name: test MINGW32
       run: |
         set MSYSTEM=MINGW32
-        msys2do ./test.sh
+        msys2do ./test.sh MINGW32
 
   undef:
     strategy:
@@ -35,7 +35,7 @@ jobs:
       uses: ./
       with:
         msystem: ${{ matrix.task }}
-    - run: msys2do ./test.sh
+    - run: msys2do ./test.sh ${{ matrix.task }}
 
   update:
     strategy:
@@ -51,4 +51,4 @@ jobs:
       with:
         update: True
         msystem: ${{ matrix.task }}
-    - run: msys2do ./test.sh
+    - run: msys2do ./test.sh ${{ matrix.task }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,8 @@
 name: 'action'
 on: [ push, pull_request ]
 jobs:
-  set:
+
+  powershell:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
@@ -11,18 +12,63 @@ jobs:
       uses: ./
     - name: test MSYS
       run: |
+        $env:MSYSTEM = 'MSYS'
+        msys2do ./test.sh MSYS
+    - name: test MINGW64
+      run: |
+        $env:MSYSTEM = 'MINGW64'
+        msys2do ./test.sh MINGW64
+    - name: test MINGW32
+      run: |
+        $env:MSYSTEM = 'MINGW32'
+        msys2do ./test.sh MINGW32
+
+  cmd:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: install deps
+      run: npm ci
+    - name: run action
+      uses: ./
+    - name: test MSYS
+      shell: cmd
+      run: |
         set MSYSTEM=MSYS
         msys2do ./test.sh MSYS
     - name: test MINGW64
+      shell: cmd
       run: |
         set MSYSTEM=MINGW64
         msys2do ./test.sh MINGW64
     - name: test MINGW32
+      shell: cmd
       run: |
         set MSYSTEM=MINGW32
         msys2do ./test.sh MINGW32
 
-  undef:
+  env:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: install deps
+      run: npm ci
+    - name: run action
+      uses: ./
+    - name: test MSYS
+      run: msys2do ./test.sh MSYS
+      env:
+        MSYSTEM: MSYS
+    - name: test MINGW64
+      run: msys2do ./test.sh MINGW64
+      env:
+        MSYSTEM: MINGW64
+    - name: test MINGW32
+      run: msys2do ./test.sh MINGW32
+      env:
+        MSYSTEM: MINGW32
+
+  msystem:
     strategy:
       matrix:
         task: [ MSYS, MINGW64, MINGW32 ]

--- a/test.sh
+++ b/test.sh
@@ -3,3 +3,8 @@
 uname -a
 
 env | grep MSYS
+
+if [ "x$MSYSTEM" != "x$1" ]; then
+  echo "Error MSYSTEM: '$MSYSTEM' != '$1'"
+  exit 1
+fi


### PR DESCRIPTION
**This PR is based on #18**

In the last execution of `master`, job `set` works as expected: https://github.com/numworks/setup-msys2/runs/271213127#step:7:14. However, in the latest PRs, it does not:

- https://github.com/numworks/setup-msys2/pull/15/checks?check_run_id=322337129#step:7:20
https://github.com/numworks/setup-msys2/pull/14/checks?check_run_id=322323700#step:7:25

This is because the default shell in `windows-latest` changed in the last month from `cmd` to `powershell`:

- https://github.blog/changelog/2019-10-17-github-actions-default-shell-on-windows-runners-is-changing-to-powershell/
- https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell

In this PR, the shell is specified, so that `set` is properly executed. Furthermore, two similar jobs are added: one to use powershell syntax (`$env:MSYSTEM = 'MINGW32'`) and another one to set the envvars in the `env` fields of the workflow.