### PR TITLE
test: fail if MSYSTEM does not contain the expected value

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,15 @@ jobs:
     - name: test MSYS
       run: |
         set MSYSTEM=MSYS
-        msys2do ./test.sh
+        msys2do ./test.sh MSYS
     - name: test MINGW64
       run: |
         set MSYSTEM=MINGW64
-        msys2do ./test.sh
+        msys2do ./test.sh MINGW64
     - name: test MINGW32
       run: |
         set MSYSTEM=MINGW32
-        msys2do ./test.sh
+        msys2do ./test.sh MINGW32
 
   undef:
     strategy:
@@ -35,7 +35,7 @@ jobs:
       uses: ./
       with:
         msystem: ${{ matrix.task }}
-    - run: msys2do ./test.sh
+    - run: msys2do ./test.sh ${{ matrix.task }}
 
   update:
     strategy:
@@ -51,4 +51,4 @@ jobs:
       with:
         update: True
         msystem: ${{ matrix.task }}
-    - run: msys2do ./test.sh
+    - run: msys2do ./test.sh ${{ matrix.task }}

--- a/test.sh
+++ b/test.sh
@@ -3,3 +3,8 @@
 uname -a
 
 env | grep MSYS
+
+if [ "x$MSYSTEM" != "x$1" ]; then
+  echo "Error MSYSTEM: '$MSYSTEM' != '$1'"
+  exit 1
+fi


### PR DESCRIPTION
Close #17

Test 'set' is expected to fail. This PR is precisely to show that the current CI workflow is broken. See #16.